### PR TITLE
fix up comment highlighting

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -114,9 +114,9 @@ syn keyword elmBuiltinFunction connect
 syn keyword elmBuiltinFunction dimensions width height
 
 " Comments
-syn match elmTodo "[tT][oO][dD][oO]" contained
-syn match elmLineComment "--.*"
-syn region elmComment start="{-" end="-}" contains=elmTodo,elmComment
+syn match elmTodo "[tT][oO][dD][oO]\|FIXME\|XXX" contained
+syn match elmLineComment "--.*" contains=elmTodo,@spell
+syn region elmComment matchgroup=elmComment start="{-" end="-}" contains=elmTodo,elmComment,@spell
 
 " String literals
 syn region elmString start="\"" skip="\\\"" end="\"" contains=elmStringEscape


### PR DESCRIPTION
- TODO (and its variants) now highlight as normal
- Nested comments now work
- Spelling is checked in comments (and not in code)

The method of getting nested comments to work (adding `matchgroup=...`) is still a bit magical to me.  [The documentation](http://vimdoc.sourceforge.net/htmldoc/usr_44.html#44.7) didn't help very much... but it works :) .
