### PR TITLE
Define elm comment convention

### DIFF
--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -108,3 +108,8 @@ command -buffer ElmMakeMain         call ElmMakeMain()
 command -buffer ElmMakeCurrentFile  call ElmMakeCurrentFile()
 command -buffer ElmClearCachedFiles call ElmClearCachedFiles()
 command -buffer ElmRepl             call ElmRepl()
+
+" Define comment convention
+
+setlocal comments=:--
+setlocal commentstring=--%s


### PR DESCRIPTION
So that comment manipulating plugins (e.g. https://github.com/tpope/vim-commentary ) do the right thing, rather than the default of `/* ... */`.
