### PR TITLE
Added bit of regex to support documentation-style comments e.g. the

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -116,7 +116,7 @@ syn keyword elmBuiltinFunction dimensions width height
 " Comments
 syn match elmTodo "[tT][oO][dD][oO]\|FIXME\|XXX" contained
 syn match elmLineComment "--.*" contains=elmTodo,@spell
-syn region elmComment matchgroup=elmComment start="{-" end="-}" contains=elmTodo,elmComment,@spell
+syn region elmComment matchgroup=elmComment start="{-|\=" end="-}" contains=elmTodo,elmComment,@spell
 
 " String literals
 syn region elmString start="\"" skip="\\\"" end="\"" contains=elmStringEscape


### PR DESCRIPTION
ones that start with a {-| and end with a -} as described in [this page](http://library.elm-lang.org/Documentation.html).
