### PR TITLE
Massively obliterate the syntax file

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -10,14 +10,14 @@ endif
 " Keywords
 syn keyword elmKeyword alias as case else if import in let module of port then type where
 
+" Builtin operators
 syn match elmBuiltinOp "\~"
 syn match elmBuiltinOp "||"
 syn match elmBuiltinOp "|>"
 syn match elmBuiltinOp "|"
 syn match elmBuiltinOp "`"
-syn match elmBuiltinOp "^"
+syn match elmBuiltinOp "\^"
 syn match elmBuiltinOp "\\"
-"syn match elmBuiltinOp "\'"
 syn match elmBuiltinOp ">>"
 syn match elmBuiltinOp ">="
 syn match elmBuiltinOp ">"
@@ -44,38 +44,6 @@ syn match elmBuiltinOp "*"
 syn match elmBuiltinOp "&&"
 syn match elmBuiltinOp "%"
 
-" Builtin operators
-"syn match elmBuiltinOp "\.\."
-"syn match elmBuiltinOp "|\{,2\}"
-"syn match elmBuiltinOp ":"
-"syn match elmBuiltinOp "::"
-"syn match elmBuiltinOp "="
-"syn match elmBuiltinOp "\\"
-"syn match elmBuiltinOp "\""
-"syn match elmBuiltinOp "->"
-"syn match elmBuiltinOp "<-"
-"syn match elmBuiltinOp "\$"
-"syn match elmBuiltinOp "&&"
-"syn match elmBuiltinOp "+"
-"syn match elmBuiltinOp "++"
-"syn match elmBuiltinOp "-"
-"syn match elmBuiltinOp "\."
-"syn match elmBuiltinOp "/"
-"syn match elmBuiltinOp "/="
-"syn match elmBuiltinOp "<"
-"syn match elmBuiltinOp "<="
-"syn match elmBuiltinOp "=="
-"syn match elmBuiltinOp ">"
-"syn match elmBuiltinOp ">="
-"syn match elmBuiltinOp "\^"
-"syn match elmBuiltinOp "\*"
-"syn match elmBuiltinOp "<\~"
-"syn match elmBuiltinOp "\~"
-
-" Builtin types
-syn keyword elmBuiltinType Bool Char False Float GT Int Just LT Maybe Nothing String True
-syn keyword elmBuiltinType Time Date Text Order Element List Signal Tuple Either
-
 " Special names
 syntax match specialName "^main "
 
@@ -93,13 +61,14 @@ syn match elmStringEscape "\\[nrfvbt\\\"]" contained
 syn match elmNumber "\(\<\d\+\>\)"
 syn match elmNumber "\(\<\d\+\.\d\+\>\)"
 
+" Types
+syn match elmType "\<[A-Z][A-Za-z_'-]*"
+
 let b:current_syntax = "elm"
 
 hi def link elmKeyword            Keyword
 hi def link elmBuiltinOp          Special
-hi def link elmBuiltinType        Type
-hi def link elmBuiltinFunction    Function
-hi def link elmCoreLibrary        Type
+hi def link elmType               Type
 hi def link elmTodo               Todo
 hi def link elmLineComment        Comment
 hi def link elmComment            Comment


### PR DESCRIPTION
Based on discussion with Evan and others [here](https://groups.google.com/forum/#!searchin/elm-discuss/pygments/elm-discuss/RXhWQ650y2Y/qhbF-DDBrXsJ), I think this updated syntax file is more in line with Elm 0.14 as well as my own preferences (no special treatment for standard libs).
