### PR TITLE
Update for 0.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Nothing other than vim is needed for the syntax highlighting.
 
 For the special commands and aliases (for compilation, etc), the plugin expects the following programs to be available:
 
-* `elm`: The Elm compiler.
+* `elm-make`: The Elm compiler.
 * `elm-repl`: The Elm REPL. The plugin sends it bits of code for evaluation.
 
 ## Usage
@@ -20,7 +20,7 @@ you should create mappings according to your needs.
 
 * `:ElmMakeCurrentFile` compiles the current file.
 * `:ElmMakeMain` compiles an assumed `Main.elm` file.
-* `:ElmPrintTypes` displays the types of the current file in a new split window.
+* `:ElmMakeFile <filename>` compiles `filename`.
 
 ### Evaluation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Nothing other than vim is needed for the syntax highlighting.
 
 For the special commands and aliases (for compilation, etc), the plugin expects the following programs to be available:
 
-* `elm-make`: The Elm compiler.
+* `elm-make`: The Elm build tool.
 * `elm-repl`: The Elm REPL. The plugin sends it bits of code for evaluation.
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ I use the following mappings in my .vimrc at the moment:
 
     nnoremap <leader>el :ElmEvalLine<CR>
     vnoremap <leader>es :<C-u>ElmEvalSelection<CR>
-    nnoremap <leader>ep :ElmPrintTypes<CR>
     nnoremap <leader>em :ElmMakeCurrentFile<CR>
 
 ### Example autocommands

--- a/autoload/elm/io.vim
+++ b/autoload/elm/io.vim
@@ -6,17 +6,3 @@ function! elm#io#system(program, args)
   return system(cmd)
 endfunction
 
-" Run system command and put its output into a new window.
-function! elm#io#read_into_new_window(cmd) abort
-  try
-    new
-    exec "read! " . a:cmd
-    " setlocal buftype=nowrite nomodified filetype=elm
-    setlocal buftype=nowrite nomodified
-    nnoremap <buffer> <silent> q    :<C-U>bdelete<CR>
-    return ''
-  catch /^*/
-    return 'echoerr v:errmsg'
-  endtry
-endfunction
-

--- a/doc/elm-vim.txt
+++ b/doc/elm-vim.txt
@@ -1,4 +1,4 @@
-elm.txt   Last change 2014 October 9
+*elm-vim.txt*   For Vim version 7.3   Last change: 2015 April 8
 ===============================================================================
 ===============================================================================
              oooo                                     o8o
@@ -9,16 +9,16 @@ elm.txt   Last change 2014 October 9
    888    .o  888   888   888   888  .o.    `888'     888   888   888   888
    `Y8bod8P' o888o o888o o888o o888o Y8P     `8'     o888o o888o o888o o888o
 ===============================================================================
-CONTENTS                                                         elm-contents
+CONTENTS                                                         elm-contents~
 
-  1. Features:                                         elm-features
-  2. Requirements:                                     elm-requirements
-  3. Functions:                                        elm-functions
-  4. Troubleshooting:                                  elm-troubleshooting
-  5. Information:                                      elm-information
+  1. Features:                                         |elm-features|
+  2. Requirements:                                     |elm-requirements|
+  3. Functions:                                        |elm-functions|
+  4. Troubleshooting:                                  |elm-troubleshooting|
+  5. Information:                                      |elm-information|
 
 ===============================================================================
-FEATURES                                                         elm-features
+FEATURES                                                         *elm-features*
 
   * Syntax Highlighting
   * Indentation
@@ -27,45 +27,43 @@ FEATURES                                                         elm-features
   * REPL inside vim
 
 ===============================================================================
-REQUIREMENTS                                                 elm-requirements
+REQUIREMENTS                                                 *elm-requirements*
 
   * Elm (http://elm-lang.org/)
 
 ===============================================================================
-FUNCTIONS                                                       elm-functions
+FUNCTIONS                                                       elm-functions~
 
-ElmMake                                                               ElmMake
+ElmMake                                                               *ElmMake*
   This takes a file as an argument and compiles it using elm. It isn't
   typically called by the user, but is instead used by ElmMakeCurrentFile and
   ElmMakeMain.
 
-ElmMakeCurrentFile                                         ElmMakeCurrentFile
-  This compiles the file currently being edited using elm.
+ElmMakeCurrentFile                                         *ElmMakeCurrentFile*
+  This compiles the file currently being edited using elm.  Note that it is 
+  possible to pass in command-line options by appending them to the filename
+  string.
 
-ElmMakeMain                                                       ElmMakeMain
+ElmMakeMain                                                       *ElmMakeMain*
   This compiles "Main.elm", no matter what the current file is.
 
-ElmPrintTypes                                                   ElmPrintTypes
-  This splits the current window and displays all the types of the current
-  file in the new window.
-
-ElmEvalLine                                                       ElmEvalLine
+ElmEvalLine                                                       *ElmEvalLine*
   This takes the selected line and evaluates it with elm, then pipes the
   result to a new line below it.
 
-ElmEvalSelection                                             ElmEvalSelection
+ElmEvalSelection                                             *ElmEvalSelection*
   This is like ElmEvalLine, but works on a visual mode selection instead of
   the current line.
 
-ElmRepl                                                               ElmRepl
+ElmRepl                                                               *ElmRepl*
   This switches from the current file to elm-repl and remains there until the
   the repl is exited.
 
 ===============================================================================
-TROUBLESHOOTING                                           elm-troubleshooting
+TROUBLESHOOTING                                           elm-troubleshooting~
 
 If something's broken, first make sure you have elm installed and in your path
-(if 'elm' on the command line returns something along the lines of "command not
+(if "elm" on the command line returns something along the lines of "command not
 found" then one of those things is probably not true) and that your filetype is
 elm (":set ft?" in vim returns the current filetype to check this). If both
 of these things are true, check the issue tracker on github, and if no one
@@ -73,7 +71,7 @@ there has the same issue as you, submit an issue with a detailed description of
 your problem.
 
 ===============================================================================
-INFORMATION                                                   elm-information
+INFORMATION                                                   elm-information~
 
 Author: lambdatoast
 Homepage: https://github.com/lambdatoast/elm.vim
@@ -82,4 +80,4 @@ Documentation by japesinator
 
 ===============================================================================
 ===============================================================================
-" vim:ft=help:et:ts=2:sw=2:sts=2:norl:
+ vim:tw=78:ts=8:ft=help:norl:

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -12,19 +12,9 @@ let b:did_ftplugin = 1
 
 " Compilation
 
-" function! ElmPrintTypes()
-"   let file = expand("%")
-"   let tmpname = "tmp.elm.vim.plugin"
-"   let buildDir = tmpname . ".build"
-"   let cacheDir = tmpname . ".cache"
-"   let compilercmd = "elm " . "--build-dir=" . buildDir . " --cache-dir=" . cacheDir . " --print-types " . file
-"   let cleanUpCmd = "rm -rf " . buildDir . " " . cacheDir
-"   return elm#io#read_into_new_window(compilercmd . " && " . cleanUpCmd)
-" endfunction
-
 function! ElmMake(file)
-  let args = "--make " . a:file
-  return elm#io#system("elm", args)
+  let args = a:file
+  return elm#io#system("elm-make", args)
 endfunction
 
 function! ElmMakeCurrentFile()
@@ -38,12 +28,6 @@ endfunction
 function! ElmMakeFile(file)
   echo ElmMake(a:file)
 endfunction
-
-" File management
-
-" function! ElmClearCachedFiles()
-"   echo elm#io#system("rm", "-rf build cache")
-" endfunction
 
 " REPL
 
@@ -87,11 +71,9 @@ endfunction
 
 command -buffer ElmEvalLine          call ElmEvalLine()
 command -buffer ElmEvalSelection     call ElmEvalSelection()
-" command -buffer ElmPrintTypes        call ElmPrintTypes()
 command -buffer ElmMakeMain          call ElmMakeMain()
 command -buffer -nargs=1 ElmMakeFile call ElmMakeFile <args>
 command -buffer ElmMakeCurrentFile   call ElmMakeCurrentFile()
-" command -buffer ElmClearCachedFiles  call ElmClearCachedFiles()
 command -buffer ElmRepl              call ElmRepl()
 
 " Define comment convention

--- a/ftplugin/elm.vim
+++ b/ftplugin/elm.vim
@@ -1,6 +1,6 @@
 " elm.vim - Plugin for the Elm programming language
 " Maintainer:   Alexander Noriega <http://lambdatoast.com/>
-" Version:      0.4.2
+" Version:      0.4.3
 
 " Plugin setup stuff
 
@@ -12,15 +12,15 @@ let b:did_ftplugin = 1
 
 " Compilation
 
-function! ElmPrintTypes()
-  let file = expand("%")
-  let tmpname = "tmp.elm.vim.plugin"
-  let buildDir = tmpname . ".build"
-  let cacheDir = tmpname . ".cache"
-  let compilercmd = "elm " . "--build-dir=" . buildDir . " --cache-dir=" . cacheDir . " --print-types " . file
-  let cleanUpCmd = "rm -rf " . buildDir . " " . cacheDir
-  return elm#io#read_into_new_window(compilercmd . " && " . cleanUpCmd)
-endfunction
+" function! ElmPrintTypes()
+"   let file = expand("%")
+"   let tmpname = "tmp.elm.vim.plugin"
+"   let buildDir = tmpname . ".build"
+"   let cacheDir = tmpname . ".cache"
+"   let compilercmd = "elm " . "--build-dir=" . buildDir . " --cache-dir=" . cacheDir . " --print-types " . file
+"   let cleanUpCmd = "rm -rf " . buildDir . " " . cacheDir
+"   return elm#io#read_into_new_window(compilercmd . " && " . cleanUpCmd)
+" endfunction
 
 function! ElmMake(file)
   let args = "--make " . a:file
@@ -41,11 +41,11 @@ endfunction
 
 " File management
 
-function! ElmClearCachedFiles()
-  echo elm#io#system("rm", "-rf build cache")
-endfunction
+" function! ElmClearCachedFiles()
+"   echo elm#io#system("rm", "-rf build cache")
+" endfunction
 
-" REPL 
+" REPL
 
 function! ElmRepl()
   !elm-repl
@@ -87,11 +87,11 @@ endfunction
 
 command -buffer ElmEvalLine          call ElmEvalLine()
 command -buffer ElmEvalSelection     call ElmEvalSelection()
-command -buffer ElmPrintTypes        call ElmPrintTypes()
+" command -buffer ElmPrintTypes        call ElmPrintTypes()
 command -buffer ElmMakeMain          call ElmMakeMain()
 command -buffer -nargs=1 ElmMakeFile call ElmMakeFile <args>
 command -buffer ElmMakeCurrentFile   call ElmMakeCurrentFile()
-command -buffer ElmClearCachedFiles  call ElmClearCachedFiles()
+" command -buffer ElmClearCachedFiles  call ElmClearCachedFiles()
 command -buffer ElmRepl              call ElmRepl()
 
 " Define comment convention

--- a/indent/elm.vim
+++ b/indent/elm.vim
@@ -8,118 +8,118 @@
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
-  finish
+    finish
 endif
 let b:did_indent = 1
 
 setlocal indentexpr=HaskellIndent()
 for i in split('0{,:,0#,e', ',')
-  exec "setlocal indentkeys-=" . i
+    exec "setlocal indentkeys-=" . i
 endfor
 setlocal indentkeys+=0=else,0=in,0=where,0),0<bar>
 setlocal tabstop=8
 setlocal expandtab
 
 if !exists('g:Haskell_no_mapping')
-  inoremap <silent> <BS> <C-R>=<SID>HaskellDedent(1)<CR>
-  inoremap <silent> <C-D> <C-R>=<SID>HaskellDedent(0)<CR>
+    inoremap <silent> <BS> <C-R>=<SID>HaskellDedent(1)<CR>
+    inoremap <silent> <C-D> <C-R>=<SID>HaskellDedent(0)<CR>
 endif
 
 " Only define the functions once.
 if exists("*HaskellIndent")
-  finish
+    finish
 endif
 
 let s:align_map = {
-      \ 'in': '\<let\>',
-      \ 'else': '\<then\>',
-      \ ',': '\v%(\s|\w|^)@<=[[{]%(\s|\w|"|$)@='
-      \ }
+            \ 'in': '\<let\>',
+            \ '\<else\>': '\<then\>',
+            \ ',': '\v%(\s|\w|^)@<=[[{]%(\s|\w|"|$)@='
+            \ }
 let s:indent_self = ['=']
 let s:indent_next = ['let', 'in', 'where', 'do', 'if']
 let s:indent_if_final = ['=', 'do', '->', 'of', 'where']
 
 function HaskellIndent()
-  let lnum = v:lnum - 1
+    let lnum = v:lnum - 1
 
-  " Hit the start of the file, use zero indent.
-  if lnum == 0
-    return 0
-  endif
-
-  let ind = indent(lnum)
-  let prevline = getline(lnum)
-  let curline = getline(v:lnum)
-  let curwords = split(curline)
-  if len(curwords) > 0 
-    if has_key(s:align_map, curwords[0])
-      let word = s:align_map[curwords[0]]
-      let m = -1
-      let line = v:lnum
-      while m == -1
-	let line -= 1
-	if line <= 0
-	  return -1
-	endif
-	let m = match(getline(line), word)
-      endwhile
-      return m
-    elseif index(s:indent_self, curwords[0]) != -1
-      return ind + &sw
-    elseif curwords[0] == '|'
-      return match(prevline, '\v%(\s|\w|^)@<=[|=]%(\s|\w)@=')
-    elseif index([')', '}'], curwords[0]) != -1
-      return ind - &sw
-    elseif curwords[0] == 'where'
-      if prevline =~ '\v^\s+\|%(\s|\w)@='
-	return ind - 1
-      endif
+    " Hit the start of the file, use zero indent.
+    if lnum == 0
+        return 0
     endif
-  endif
 
-  let prevwords = split(prevline)
-  if len(prevwords) == 0
-    return 0
-  endif
+    let ind = indent(lnum)
+    let prevline = getline(lnum)
+    let curline = getline(v:lnum)
+    let curwords = split(curline)
+    if len(curwords) > 0
+        if has_key(s:align_map, curwords[0])
+            let word = s:align_map[curwords[0]]
+            let m = -1
+            let line = v:lnum
+            while m == -1
+                let line -= 1
+                if line <= 0
+                    return -1
+                endif
+                let m = match(getline(line), word)
+            endwhile
+            return m
+        elseif index(s:indent_self, curwords[0]) != -1
+            return ind + &sw
+        elseif curwords[0] == '|'
+            return match(prevline, '\v%(\s|\w|^)@<=[|=]%(\s|\w)@=')
+        elseif index([')', '}'], curwords[0]) != -1
+            return ind - &sw
+        elseif curwords[0] == 'where'
+            if prevline =~ '\v^\s+\|%(\s|\w)@='
+                return ind - 1
+            endif
+        endif
+    endif
 
-  if prevwords[-1] == 'where' && prevwords[0] == 'module'
-    return 0
-  elseif index(s:indent_if_final, prevwords[-1]) != -1
-    return ind + &sw
-  elseif prevwords[-1] =~ '\v%(\s|\w|^)@<=[[{(]$'
-    return ind + &sw
-  else
-    for word in reverse(prevwords)
-      if index(s:indent_next, word) != -1
-	return match(prevline, '\<'.word.'\>') + len(word) + 1
-      endif
-    endfor
-  endif
+    let prevwords = split(prevline)
+    if len(prevwords) == 0
+        return 0
+    endif
 
-  if len(curwords) > 0 && curwords[0] == 'where'
-    return ind + &sw
-  endif
+    if prevwords[-1] == 'where' && prevwords[0] == 'module'
+        return 0
+    elseif index(s:indent_if_final, prevwords[-1]) != -1
+        return ind + &sw
+    elseif prevwords[-1] =~ '\v%(\s|\w|^)@<=[[{(]$'
+        return ind + &sw
+    else
+        for word in reverse(prevwords)
+            if index(s:indent_next, word) != -1
+                return match(prevline, '\<'.word.'\>') + len(word) + 1
+            endif
+        endfor
+    endif
 
-  return ind
+    if len(curwords) > 0 && curwords[0] == 'where'
+        return ind + &sw
+    endif
+
+    return ind
 endfunction
 
 function s:HaskellDedent(isbs)
-  if a:isbs && strpart(getline('.'), 0, col('.')-1) !~ '^\s\+$'
-    return "\<BS>"
-  endif
-
-  let curind = indent('.')
-  let line = line('.') - 1
-  while curind > 0 && line > 0
-    let ind = indent(line) 
-    if ind >= curind
-      let line -= 1
-    else
-      echomsg curind ind
-      call setline('.', repeat(' ', ind) .
-	    \ substitute(getline('.'), '^\s\+', '', ''))
-      return ''
+    if a:isbs && strpart(getline('.'), 0, col('.')-1) !~ '^\s\+$'
+        return "\<BS>"
     endif
-  endwhile
-  return a:isbs ? "\<BS>" : ''
+
+    let curind = indent('.')
+    let line = line('.') - 1
+    while curind > 0 && line > 0
+        let ind = indent(line)
+        if ind >= curind
+            let line -= 1
+        else
+            echomsg curind ind
+            call setline('.', repeat(' ', ind) .
+                        \ substitute(getline('.'), '^\s\+', '', ''))
+            return ''
+        endif
+    endwhile
+    return a:isbs ? "\<BS>" : ''
 endfunction

--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -1,14 +1,14 @@
 " Vim syntax file
 " Language: Elm (http://elm-lang.org/)
 " Maintainer: Alexander Noriega
-" Latest Revision: 12 January 2015
+" Latest Revision: 19 April 2015
 
 if exists("b:current_syntax")
   finish
 endif
 
 " Keywords
-syn keyword elmKeyword alias as case else if import in let module of port then type where
+syn keyword elmKeyword alias as case else exposing if import in let module of port then type where
 
 " Builtin operators
 syn match elmBuiltinOp "\~"


### PR DESCRIPTION
This combines updates for 0.14 (use `elm-make` and friends instead of `elm --option`) with the addition of a single keyword (`exposing`) to be compatible with [Elm 0.15](http://elm-lang.org/blog/announce/0.15.elm).

Updated the helpfile and added some vim-helpfile markup.

Sorry about the whitespace mangling, I have something set up in my vimrc that does it automatically.


Cheers,
Alex

