### PR TITLE
Add better syntax highlighting rules

### DIFF
--- a/syntax/elm.vim
+++ b/syntax/elm.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language: Elm (http://elm-lang.org/)
 " Maintainer: Alexander Noriega
-" Latest Revision: 19 April 2015
+" Latest Revision: 11 June 2015
 
 if exists("b:current_syntax")
   finish
@@ -10,68 +10,60 @@ endif
 " Keywords
 syn keyword elmKeyword alias as case else exposing if import in let module of port then type where
 
-" Builtin operators
-syn match elmBuiltinOp "\~"
-syn match elmBuiltinOp "||"
-syn match elmBuiltinOp "|>"
-syn match elmBuiltinOp "|"
-syn match elmBuiltinOp "`"
-syn match elmBuiltinOp "\^"
-syn match elmBuiltinOp "\\"
-syn match elmBuiltinOp ">>"
-syn match elmBuiltinOp ">="
-syn match elmBuiltinOp ">"
-syn match elmBuiltinOp "=="
-syn match elmBuiltinOp "="
-syn match elmBuiltinOp "<\~"
-syn match elmBuiltinOp "<|"
-syn match elmBuiltinOp "<="
-syn match elmBuiltinOp "<<"
-syn match elmBuiltinOp "<-"
-syn match elmBuiltinOp "<"
-syn match elmBuiltinOp "::"
-syn match elmBuiltinOp ":"
-syn match elmBuiltinOp "/="
-syn match elmBuiltinOp "//"
-syn match elmBuiltinOp "/"
-syn match elmBuiltinOp "\.\."
-syn match elmBuiltinOp "\."
-syn match elmBuiltinOp "->"
-syn match elmBuiltinOp "-"
-syn match elmBuiltinOp "++"
-syn match elmBuiltinOp "+"
-syn match elmBuiltinOp "*"
-syn match elmBuiltinOp "&&"
-syn match elmBuiltinOp "%"
-
-" Special names
-syntax match specialName "^main "
-
-" Comments
-syn match elmTodo "[tT][oO][dD][oO]\|FIXME\|XXX" contained
-syn match elmLineComment "--.*" contains=elmTodo,@spell
-syn region elmComment matchgroup=elmComment start="{-|\=" end="-}" contains=elmTodo,elmComment,@spell
-
-" String literals
-syn region elmString start="\"" skip="\\\"" end="\"" contains=elmStringEscape
-syn match elmStringEscape "\\u[0-9a-fA-F]\{4}" contained
-syn match elmStringEscape "\\[nrfvbt\\\"]" contained
-
-" Number literals
-syn match elmNumber "\(\<\d\+\>\)"
-syn match elmNumber "\(\<\d\+\.\d\+\>\)"
+" Operators
+syn match elmOperator "\([-!#$%&\*\+./<=>\?@\\^|~:]\|\<_\>\)"
+syn match elmBacktick "`[A-Za-z][A-Za-z0-9_]*\('\)*`"
 
 " Types
 syn match elmType "\<[A-Z][0-9A-Za-z_'-]*"
 
-let b:current_syntax = "elm"
+" Booleans
+syn keyword elmBoolean True False
 
-hi def link elmKeyword            Keyword
-hi def link elmBuiltinOp          Special
-hi def link elmType               Type
-hi def link elmTodo               Todo
-hi def link elmLineComment        Comment
-hi def link elmComment            Comment
-hi def link elmString             String
-hi def link elmNumber             Number
-hi def link specialName           Special
+" Delimiters
+syn match elmDelimiter  "[(),;[\]{}]"
+
+" Functions
+syn match elmTupleFunction "\((,\+)\)"
+
+" Comments
+syn keyword elmTodo TODO FIXME XXX contained
+syn match elmLineComment "--.*" contains=elmTodo,@spell
+syn region elmComment matchgroup=elmComment start="{-|\=" end="-}" contains=elmTodo,elmComment,@spell
+
+" Strings
+syn match elmStringEscape "\\u[0-9a-fA-F]\{4}" contained
+syn match elmStringEscape "\\[nrfvbt\\\"]" contained
+syn region elmString start="\"" skip="\\\"" end="\"" contains=elmStringEscape
+syn region elmTripleString start="\"\"\"" skip="\\\"" end="\"\"\"" contains=elmStringEscape
+syn match elmChar "'[^'\\]'\|'\\.'\|'\\u[0-9a-fA-F]\{4}'"
+
+" Numbers
+syn keyword elmNumberType number
+syn match elmInt "\(\<\d\+\>\)"
+syn match elmFloat "\(\<\d\+\.\d\+\>\)"
+
+" Identifiers
+syn match elmIdentifier "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*" contained
+syn match elmTopLevelDecl "^\s*[a-zA-Z][a-zA-z0-9_]*\('\)*\s\+:\s\+" contains=elmIdentifier,elmOperator
+
+hi def link elmIdentifier Identifier
+hi def link elmKeyword Keyword
+hi def link elmOperator Operator
+hi def link elmBacktick Operator
+hi def link elmTupleFunction Normal
+hi def link elmBoolean Boolean
+hi def link elmType Type
+hi def link elmTodo Todo
+hi def link elmLineComment Comment
+hi def link elmComment Comment
+hi def link elmString String
+hi def link elmTripleString String
+hi def link elmChar String
+hi def link elmStringEscape Special
+hi def link elmNumberType Type
+hi def link elmInt Number
+hi def link elmFloat Number
+hi def link elmDelimiter Delimiter
+
+let b:current_syntax = "elm"


### PR DESCRIPTION
The changes are a bit opinionated, so I have listed them all below. I have tested this new syntax file on all the large Elm codebases I could find, and haven't noticed any issues.

* Simpler operator rule that covers any user created operators as well
* Treat back tick functions as operators, e.g. \`andThen\`
* Removed 'main' as a special name
* Even though they are just types, treat 'True' and 'False'  as booleans for highlighting
* Highlight special tuple functions as normal identifiers, e.g. (,,,)
* Simplify the TODO comment highlighting to remove false positives in normal comments
* Add support for triple quoted strings
* Highlight string escapes
* Add support for Char literals
* Highlight the 'number' type as a normal elm Type
* Highlight identifiers in top level type declarations