### PR TITLE
Remove and ignore doc/tags.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/doc/tags


### PR DESCRIPTION
Hiya,

IMHO `doc/tags` should be generated by the user (or Pathogen, Vundle, etc).

Thank you,
Brett