### PR TITLE
Adding a symbolic link to ftplugin->plugin for Vundle install

### DIFF
--- a/plugin
+++ b/plugin
@@ -1,0 +1,1 @@
+ftplugin


### PR DESCRIPTION
This allows [vundle](https://github.com/VundleVim/Vundle.vim) to pick up the plugin files. Helps solve some install issues in #14.

UPDATE: This may be an older directory structure as I was linking to `gmarik/vundle` in my bundle.vim config. Updating may also help with issue #14.
