### PR TITLE
committing auto-generated doc/tags

### DIFF
--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,9 @@
+ElmEvalLine	elm-vim.txt	/*ElmEvalLine*
+ElmEvalSelection	elm-vim.txt	/*ElmEvalSelection*
+ElmMake	elm-vim.txt	/*ElmMake*
+ElmMakeCurrentFile	elm-vim.txt	/*ElmMakeCurrentFile*
+ElmMakeMain	elm-vim.txt	/*ElmMakeMain*
+ElmRepl	elm-vim.txt	/*ElmRepl*
+elm-features	elm-vim.txt	/*elm-features*
+elm-requirements	elm-vim.txt	/*elm-requirements*
+elm-vim.txt	elm-vim.txt	/*elm-vim.txt*


### PR DESCRIPTION
I have this plugin installed as a git submodule and because the tags file would update every time vim started, this plugin always showed up as modified (with the same content, every time.)

Minor, but I though it wouldn't hurt to have it committed and prevent git from complaining about modified content in a submodule.

Thanks for the plugin btw -- works great.